### PR TITLE
Options and bufixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ To create the marker controls, enter the following code:
 var marker_controls = new L.Control.SimpleMarkers();
 map.addControl(marker_controls);
 ```
+
+###Available Options
+
+`add_control`: Show the add marker button should be shown. Possible values: `true`, `false`. Default: `true`.
+`delete_control`: Show the delete marker button should be shown. Possible values: `true`, `false`. Default: `true`.
+`allow_popup`: Create and bind a popup for each marker.  Possible values: `true`, `false`. Default: `true`.
+`marker_icon`: Use a custom icon instance. If not given, the default Leaflet icon will be shown. Possible values: Leaflet icon instance, `undefined`. Default: `undefined`.
+`marker_draggable`: Allow dragging of markers. Possible values: `true`, `false`. Default: `false`.
+`add_marker_callback`: Run a callback function with the marker instance as argument. Possible values: Callback function, `undefined`. Default: `undefined`.
+

--- a/index.html
+++ b/index.html
@@ -1,43 +1,37 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Simple Markers</title>
-    
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
-	<!--[if lte IE 8]><link rel="stylesheet" href="libs/leaflet.ie.css" /><![endif]-->
-    	<link rel="stylesheet" href="lib/Control.SimpleMarkers.css" />
-    
-	<script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
-    	<script src="lib/Control.SimpleMarkers.js"></script>
-    
-	 <style type="text/css">
-	        body, html {
-	            height: 100%;
-	            
-	        }
-	        
-	        #map {
-	            width: 100%;
-	            height: 99%;
-	            
-	        }
-     	</style>
+  <title>Simple Markers</title>
+  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+  <!--[if lte IE 8]><link rel="stylesheet" href="libs/leaflet.ie.css" /><![endif]-->
+  <link rel="stylesheet" href="lib/Control.SimpleMarkers.css" />
+  <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+  <script src="lib/Control.SimpleMarkers.js"></script>
+  <style type="text/css">
+    body, html {
+      height: 100%;
+    }
+    #map {
+      width: 100%;
+      height: 99%;
+    }
+  </style>
 </head>
 <body>
-	<div id="map"></div>
-	
-	<script type="text/JavaScript">
-    
-        // Create the map
-		var osmUrl = 'http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpg',
-			osm = new L.TileLayer(osmUrl, {maxZoom: 18, attribution: "Map data &copy; OpenStreetMap contributors"}),
-			map = new L.Map('map', {layers: [osm], center: new L.LatLng(39.8282, -98.5795), zoom: 4});
-        
-        
-        // Create the marker controls
-        var marker_controls = new L.Control.SimpleMarkers();
-        map.addControl(marker_controls);
-        
-	</script>
+  <div id="map"></div>
+
+  <script type="text/JavaScript">
+
+    // Create the map
+    var osmUrl = 'http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpg',
+        osm = new L.TileLayer(osmUrl, {maxZoom: 18, attribution: "Map data &copy; OpenStreetMap contributors"}),
+        map = new L.Map('map', {layers: [osm], center: new L.LatLng(39.8282, -98.5795), zoom: 4});
+
+
+    // Create the marker controls
+    var marker_controls = new L.Control.SimpleMarkers();
+    map.addControl(marker_controls);
+
+  </script>
 </body>
 </html>

--- a/lib/Control.SimpleMarkers.js
+++ b/lib/Control.SimpleMarkers.js
@@ -1,22 +1,29 @@
 L.Control.SimpleMarkers = L.Control.extend({
     options: {
-        position: 'topleft'
+        position: 'topleft',
+        add_control: true,
+        delete_control: true
     },
 
     onAdd: function () {
         var marker_container = L.DomUtil.create('div', 'marker_controls');
-        var add_marker_div = L.DomUtil.create('div', 'add_marker_control', marker_container);
-        var del_marker_div = L.DomUtil.create('div', 'del_marker_control', marker_container);
-        add_marker_div.title = 'Add a marker';
-        del_marker_div.title = 'Delete a marker';
 
-        L.DomEvent.addListener(add_marker_div, 'click', L.DomEvent.stopPropagation)
-            .addListener(add_marker_div, 'click', L.DomEvent.preventDefault)
-            .addListener(add_marker_div, 'click', (function () { this.enterAddMarkerMode() }).bind(this));
+        if (this.options.add_control) {
+            var add_marker_div = L.DomUtil.create('div', 'add_marker_control', marker_container);
+            add_marker_div.title = 'Add a marker';
+            L.DomEvent.addListener(add_marker_div, 'click', L.DomEvent.stopPropagation)
+                .addListener(add_marker_div, 'click', L.DomEvent.preventDefault)
+                .addListener(add_marker_div, 'click', (function () { this.enterAddMarkerMode() }).bind(this));
+        }
+        if (this.options.delete_control) {
+            var del_marker_div = L.DomUtil.create('div', 'del_marker_control', marker_container);
+            del_marker_div.title = 'Delete a marker';
 
-        L.DomEvent.addListener(del_marker_div, 'click', L.DomEvent.stopPropagation)
-            .addListener(del_marker_div, 'click', L.DomEvent.preventDefault)
-            .addListener(del_marker_div, 'click', (function () { this.enterDelMarkerMode() }).bind(this));
+
+            L.DomEvent.addListener(del_marker_div, 'click', L.DomEvent.stopPropagation)
+                .addListener(del_marker_div, 'click', L.DomEvent.preventDefault)
+                .addListener(del_marker_div, 'click', (function () { this.enterDelMarkerMode() }).bind(this));
+        }
 
         return marker_container;
     },

--- a/lib/Control.SimpleMarkers.js
+++ b/lib/Control.SimpleMarkers.js
@@ -7,7 +7,8 @@ L.Control.SimpleMarkers = L.Control.extend({
         delete_control: true,
         allow_popup: true,
         marker_icon: undefined,
-        marker_draggable: false
+        marker_draggable: false,
+        add_marker_callback: undefined
     },
     map: undefined,
     markerList: [],
@@ -70,13 +71,16 @@ L.Control.SimpleMarkers = L.Control.extend({
             marker_options.icon = this.options.marker_icon;
         }
         var marker = L.marker(e.latlng, marker_options);
-        marker.addTo(this.map);
         if (this.options.allow_popup) {
             var popupContent =  "You clicked on the map at " + e.latlng.toString();
             var the_popup = L.popup({maxWidth: 160, closeButton: false});
             the_popup.setContent(popupContent);
             marker.bindPopup(the_popup).openPopup();
         }
+        if (this.options.add_marker_callback) {
+            this.options.add_marker_callback(marker);
+        }
+        marker.addTo(this.map);
         this.markerList.push(marker);
 
         return false;

--- a/lib/Control.SimpleMarkers.js
+++ b/lib/Control.SimpleMarkers.js
@@ -19,7 +19,7 @@ L.Control.SimpleMarkers = L.Control.extend({
             add_marker_div.title = 'Add a marker';
             L.DomEvent.addListener(add_marker_div, 'click', L.DomEvent.stopPropagation)
                 .addListener(add_marker_div, 'click', L.DomEvent.preventDefault)
-                .addListener(add_marker_div, 'click', function () { this.enterAddMarkerMode(); }.bind(this));
+                .addListener(add_marker_div, 'click', this.enterAddMarkerMode.bind(this));
         }
         if (this.options.delete_control) {
             var del_marker_div = L.DomUtil.create('div', 'del_marker_control', marker_container);
@@ -28,7 +28,7 @@ L.Control.SimpleMarkers = L.Control.extend({
 
             L.DomEvent.addListener(del_marker_div, 'click', L.DomEvent.stopPropagation)
                 .addListener(del_marker_div, 'click', L.DomEvent.preventDefault)
-                .addListener(del_marker_div, 'click', function () { this.enterDelMarkerMode(); }.bind(this));
+                .addListener(del_marker_div, 'click', this.enterDelMarkerMode.bind(this));
         }
 
         return marker_container;
@@ -39,19 +39,20 @@ L.Control.SimpleMarkers = L.Control.extend({
         if (this.markerList !== '') {
             for (var marker = 0; marker < this.markerList.length; marker++) {
                 if (typeof(this.markerList[marker]) !== 'undefined') {
-                    this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete);
+                    this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete.bind(this));
                 }
             }
         }
-        document.getElementById('map').style.cursor = 'crosshair';
-        this.map.addEventListener('click', this.onMapClickAddMarker);
+        this.map._container.style.cursor = 'crosshair';
+        this.map.addEventListener('click', this.onMapClickAddMarker.bind(this));
     },
 
     enterDelMarkerMode: function () {
         "use strict";
         for (var marker = 0; marker < this.markerList.length; marker++) {
             if (typeof(this.markerList[marker]) !== 'undefined') {
-                this.markerList[marker].addEventListener('click', this.onMarkerClickDelete);
+                this.markerList[marker].addEventListener('click', this.onMarkerClickDelete.bind(this));
+                this.map._container.style.cursor = 'crosshair';
             }
         }
     },
@@ -59,7 +60,7 @@ L.Control.SimpleMarkers = L.Control.extend({
     onMapClickAddMarker: function (e) {
         "use strict";
         this.map.removeEventListener('click');
-        document.getElementById('map').style.cursor = 'auto';
+        this.map._container.style.cursor = 'auto';
 
         var popupContent =  "You clicked on the map at " + e.latlng.toString();
         var the_popup = L.popup({maxWidth: 160, closeButton: false});
@@ -75,13 +76,14 @@ L.Control.SimpleMarkers = L.Control.extend({
 
     onMarkerClickDelete: function (e) {
         "use strict";
+        this.map._container.style.cursor = 'auto';
         this.map.removeLayer(this);
         var marker_index = this.markerList.indexOf(this);
         delete this.markerList[marker_index];
 
         for (var marker = 0; marker < this.markerList.length; marker++) {
             if (typeof(this.markerList[marker]) !== 'undefined') {
-                this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete);
+                this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete.bind(this));
             }
         }
         return false;

--- a/lib/Control.SimpleMarkers.js
+++ b/lib/Control.SimpleMarkers.js
@@ -4,7 +4,10 @@ L.Control.SimpleMarkers = L.Control.extend({
     options: {
         position: 'topleft',
         add_control: true,
-        delete_control: true
+        delete_control: true,
+        allow_popup: true,
+        marker_icon: undefined,
+        marker_draggable: false
     },
     map: undefined,
     markerList: [],
@@ -62,13 +65,18 @@ L.Control.SimpleMarkers = L.Control.extend({
         this.map.removeEventListener('click');
         this.map._container.style.cursor = 'auto';
 
-        var popupContent =  "You clicked on the map at " + e.latlng.toString();
-        var the_popup = L.popup({maxWidth: 160, closeButton: false});
-        the_popup.setContent(popupContent);
-
-        var marker = L.marker(e.latlng);
+        var marker_options = {draggable: this.options.marker_draggable};
+        if (this.options.marker_icon) {
+            marker_options.icon = this.options.marker_icon;
+        }
+        var marker = L.marker(e.latlng, marker_options);
         marker.addTo(this.map);
-        marker.bindPopup(the_popup).openPopup();
+        if (this.options.allow_popup) {
+            var popupContent =  "You clicked on the map at " + e.latlng.toString();
+            var the_popup = L.popup({maxWidth: 160, closeButton: false});
+            the_popup.setContent(popupContent);
+            marker.bindPopup(the_popup).openPopup();
+        }
         this.markerList.push(marker);
 
         return false;

--- a/lib/Control.SimpleMarkers.js
+++ b/lib/Control.SimpleMarkers.js
@@ -2,37 +2,37 @@ L.Control.SimpleMarkers = L.Control.extend({
     options: {
         position: 'topleft'
     },
-    
+
     onAdd: function () {
         var marker_container = L.DomUtil.create('div', 'marker_controls');
         var add_marker_div = L.DomUtil.create('div', 'add_marker_control', marker_container);
         var del_marker_div = L.DomUtil.create('div', 'del_marker_control', marker_container);
         add_marker_div.title = 'Add a marker';
         del_marker_div.title = 'Delete a marker';
-        
+
         L.DomEvent.addListener(add_marker_div, 'click', L.DomEvent.stopPropagation)
             .addListener(add_marker_div, 'click', L.DomEvent.preventDefault)
             .addListener(add_marker_div, 'click', (function () { this.enterAddMarkerMode() }).bind(this));
-        
+
         L.DomEvent.addListener(del_marker_div, 'click', L.DomEvent.stopPropagation)
             .addListener(del_marker_div, 'click', L.DomEvent.preventDefault)
             .addListener(del_marker_div, 'click', (function () { this.enterDelMarkerMode() }).bind(this));
-        
+
         return marker_container;
     },
-    
+
     enterAddMarkerMode: function () {
         if (markerList !== '') {
             for (var marker = 0; marker < markerList.length; marker++) {
                 if (typeof(markerList[marker]) !== 'undefined') {
                     markerList[marker].removeEventListener('click', this.onMarkerClickDelete);
-                } 
+                }
             }
         }
         document.getElementById('map').style.cursor = 'crosshair';
         map.addEventListener('click', this.onMapClickAddMarker);
     },
-    
+
     enterDelMarkerMode: function () {
         for (var marker = 0; marker < markerList.length; marker++) {
             if (typeof(markerList[marker]) !== 'undefined') {
@@ -40,34 +40,34 @@ L.Control.SimpleMarkers = L.Control.extend({
             }
         }
     },
-    
+
     onMapClickAddMarker: function (e) {
-        map.removeEventListener('click'); 
+        map.removeEventListener('click');
         document.getElementById('map').style.cursor = 'auto';
-        
+
         var popupContent =  "You clicked on the map at " + e.latlng.toString();
         var the_popup = L.popup({maxWidth: 160, closeButton: false});
         the_popup.setContent(popupContent);
-        
+
         var marker = L.marker(e.latlng);
         marker.addTo(map);
         marker.bindPopup(the_popup).openPopup();
         markerList.push(marker);
-        
-        return false;    
+
+        return false;
     },
 
     onMarkerClickDelete: function (e) {
         map.removeLayer(this);
         var marker_index = markerList.indexOf(this);
         delete markerList[marker_index];
-        
+
         for (var marker = 0; marker < markerList.length; marker++) {
             if (typeof(markerList[marker]) !== 'undefined') {
                 markerList[marker].removeEventListener('click', arguments.callee);
-            } 
+            }
         }
-        return false;  
+        return false;
     }
 });
 

--- a/lib/Control.SimpleMarkers.js
+++ b/lib/Control.SimpleMarkers.js
@@ -1,11 +1,17 @@
+/* jshint plusplus: false */
+/* globals L */
 L.Control.SimpleMarkers = L.Control.extend({
     options: {
         position: 'topleft',
         add_control: true,
         delete_control: true
     },
-
-    onAdd: function () {
+    map: undefined,
+    markerList: [],
+    
+    onAdd: function (map) {
+        "use strict";
+        this.map = map;
         var marker_container = L.DomUtil.create('div', 'marker_controls');
 
         if (this.options.add_control) {
@@ -13,7 +19,7 @@ L.Control.SimpleMarkers = L.Control.extend({
             add_marker_div.title = 'Add a marker';
             L.DomEvent.addListener(add_marker_div, 'click', L.DomEvent.stopPropagation)
                 .addListener(add_marker_div, 'click', L.DomEvent.preventDefault)
-                .addListener(add_marker_div, 'click', (function () { this.enterAddMarkerMode() }).bind(this));
+                .addListener(add_marker_div, 'click', function () { this.enterAddMarkerMode(); }.bind(this));
         }
         if (this.options.delete_control) {
             var del_marker_div = L.DomUtil.create('div', 'del_marker_control', marker_container);
@@ -22,34 +28,37 @@ L.Control.SimpleMarkers = L.Control.extend({
 
             L.DomEvent.addListener(del_marker_div, 'click', L.DomEvent.stopPropagation)
                 .addListener(del_marker_div, 'click', L.DomEvent.preventDefault)
-                .addListener(del_marker_div, 'click', (function () { this.enterDelMarkerMode() }).bind(this));
+                .addListener(del_marker_div, 'click', function () { this.enterDelMarkerMode(); }.bind(this));
         }
 
         return marker_container;
     },
 
     enterAddMarkerMode: function () {
-        if (markerList !== '') {
-            for (var marker = 0; marker < markerList.length; marker++) {
-                if (typeof(markerList[marker]) !== 'undefined') {
-                    markerList[marker].removeEventListener('click', this.onMarkerClickDelete);
+        "use strict";
+        if (this.markerList !== '') {
+            for (var marker = 0; marker < this.markerList.length; marker++) {
+                if (typeof(this.markerList[marker]) !== 'undefined') {
+                    this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete);
                 }
             }
         }
         document.getElementById('map').style.cursor = 'crosshair';
-        map.addEventListener('click', this.onMapClickAddMarker);
+        this.map.addEventListener('click', this.onMapClickAddMarker);
     },
 
     enterDelMarkerMode: function () {
-        for (var marker = 0; marker < markerList.length; marker++) {
-            if (typeof(markerList[marker]) !== 'undefined') {
-                markerList[marker].addEventListener('click', this.onMarkerClickDelete);
+        "use strict";
+        for (var marker = 0; marker < this.markerList.length; marker++) {
+            if (typeof(this.markerList[marker]) !== 'undefined') {
+                this.markerList[marker].addEventListener('click', this.onMarkerClickDelete);
             }
         }
     },
 
     onMapClickAddMarker: function (e) {
-        map.removeEventListener('click');
+        "use strict";
+        this.map.removeEventListener('click');
         document.getElementById('map').style.cursor = 'auto';
 
         var popupContent =  "You clicked on the map at " + e.latlng.toString();
@@ -57,25 +66,24 @@ L.Control.SimpleMarkers = L.Control.extend({
         the_popup.setContent(popupContent);
 
         var marker = L.marker(e.latlng);
-        marker.addTo(map);
+        marker.addTo(this.map);
         marker.bindPopup(the_popup).openPopup();
-        markerList.push(marker);
+        this.markerList.push(marker);
 
         return false;
     },
 
     onMarkerClickDelete: function (e) {
-        map.removeLayer(this);
-        var marker_index = markerList.indexOf(this);
-        delete markerList[marker_index];
+        "use strict";
+        this.map.removeLayer(this);
+        var marker_index = this.markerList.indexOf(this);
+        delete this.markerList[marker_index];
 
-        for (var marker = 0; marker < markerList.length; marker++) {
-            if (typeof(markerList[marker]) !== 'undefined') {
-                markerList[marker].removeEventListener('click', arguments.callee);
+        for (var marker = 0; marker < this.markerList.length; marker++) {
+            if (typeof(this.markerList[marker]) !== 'undefined') {
+                this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete);
             }
         }
         return false;
     }
 });
-
-var markerList = [];

--- a/lib/Control.SimpleMarkers.js
+++ b/lib/Control.SimpleMarkers.js
@@ -12,7 +12,7 @@ L.Control.SimpleMarkers = L.Control.extend({
     },
     map: undefined,
     markerList: [],
-    
+
     onAdd: function (map) {
         "use strict";
         this.map = map;
@@ -89,15 +89,17 @@ L.Control.SimpleMarkers = L.Control.extend({
     onMarkerClickDelete: function (e) {
         "use strict";
         this.map._container.style.cursor = 'auto';
-        this.map.removeLayer(this);
-        var marker_index = this.markerList.indexOf(this);
-        delete this.markerList[marker_index];
+        if (this.markerList.indexOf(e.target)) {
+            this.map.removeLayer(e.target);
+            var marker_index = this.markerList.indexOf(e.target);
+            delete this.markerList[marker_index];
 
-        for (var marker = 0; marker < this.markerList.length; marker++) {
-            if (typeof(this.markerList[marker]) !== 'undefined') {
-                this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete.bind(this));
+            for (var marker = 0; marker < this.markerList.length; marker++) {
+                if (typeof(this.markerList[marker]) !== 'undefined') {
+                    this.markerList[marker].removeEventListener('click', this.onMarkerClickDelete);
+                }
             }
+            return false;
         }
-        return false;
     }
 });


### PR DESCRIPTION
- show the crosshair cursor also when deleting markers,
- don't use document.getElementById('map') - this restricts the plugin to maps with this id,
- all JSHint warnings corrected

I added these options:

`add_control`: Show the add marker button should be shown. Possible values: `true`, `false`. Default: `true`.
`delete_control`: Show the delete marker button should be shown. Possible values: `true`, `false`. Default: `true`.
`allow_popup`: Create and bind a popup for each marker.  Possible values: `true`, `false`. Default: `true`.
`marker_icon`: Use a custom icon instance. If not given, the default Leaflet icon will be shown. Possible values: Leaflet icon instance, `undefined`. Default: `undefined`.
`marker_draggable`: Allow dragging of markers. Possible values: `true`, `false`. Default: `false`.
`add_marker_callback`: Run a callback function with the marker instance as argument. Possible values: Callback function, `undefined`. Default: `undefined`.
